### PR TITLE
Scripts to set and restore permissions on experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+acl_files/

--- a/scripts/add_collab_experiments.sh
+++ b/scripts/add_collab_experiments.sh
@@ -1,0 +1,73 @@
+# Copyright 2024 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Add new collaborators to an experiment.
+# A collaborator is a member of the project that needs write access to the experiment
+#
+# Input:
+# experiment: the experiment name
+# users: the NCI login IDs of the new users.
+
+# Read in command line arguments (code is a mix from https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash and man getopt example) 
+help_text=0
+SHORT=e:u:h
+LONG=experiment:,users:,help
+
+PARSED=$(getopt --options $SHORT --longoptions $LONG --name "$0" -- "$@")
+if [[ $? != 0 ]] ; then echo "Wrong arguments. Terminating..." >&2 ; exit 1 ; fi
+
+
+eval set -- "$PARSED"
+
+while true; do
+    case "$1" in
+	-e|--experiment) exp_name="$2"; shift 2 ;;
+	-u|--users) users=(${2//,/ }); shift 2;;
+	-h|--help) help_text=1; shift ;;
+	--) shift; break ;;
+	*) echo "Programming error"; exit 1 ;;
+    esac
+done
+
+if [[ ${help_text} == 1 ]]; then
+    echo "The optional arguments are:"
+
+    # Experiment name
+    echo "-e, --experiment= followed by the name of the experiment. "
+    echo "    The name of the experiment should follow the format YYYY-MM-DD_<exp-title>."
+    echo
+    # Users
+    echo "-u, --users=  followed by the NCI login IDs of the new users."
+    echo
+    # Help
+    echo "-h, --help  writes this help text"
+    echo
+
+    exit 0
+fi
+
+# Parameters:
+wg_project=$(stat -c '%G' $0)
+wg_root=/g/data/${wg_project}
+
+if [ ! -d ${wg_root}/experiments/${exp_name} ]; then
+    echo "FAIL: the experiment directory ${wg_root}/experiments/${exp_name} does not exist."
+    exit 1
+fi
+
+acl_filename=${wg_root}/admin/acl_files/${exp_name}
+if [ ! -f $acl_filename ]; then
+    echo "FAIL: missing ACL file ${acl_filename}."
+    exit 1
+fi
+
+# Add ACLs for all the user IDs provided with rwx access
+for user in ${users}; do
+    acl=user:${user}:rwx
+    cat >> ${acl_filename} << EOF_gp
+${acl}
+EOF_gp
+done
+
+# Set the ACLs
+setfacl --restore=${acl_filename}

--- a/scripts/restore_acl_experiment.sh
+++ b/scripts/restore_acl_experiment.sh
@@ -38,6 +38,7 @@ fi
 
 if [ $(stat -c '%U' ${exp_path}) == $USER ]; then
     # Restore ACLs on experiment directory
+    echo Restore ACLs on the experiment directory $exp_name
     acl_filename=${wg_root}/admin/acl_files/${exp_name}
     setfacl --restore=${acl_filename}
 fi
@@ -50,4 +51,9 @@ mask_acl=mask::rwX
 # Set ACLs on files owned by the person running the script
 # We want to exclude ${exp_path} from the find results so we set mindepth=1.
 my_files=$(find ${exp_path}  -mindepth 1 -user $USER)
-setfacl -R -m ${writer_acl} -m ${default_writer_acl} -m ${mask_acl} ${my_files}
+if [ ! -z $my_files ]; then
+    echo Restore ACLs in files and directories owned by $USER within the experiment
+    setfacl -R -m ${writer_acl} -m ${default_writer_acl} -m ${mask_acl} ${my_files}
+else
+    echo No file or directory in the experiment owned by this user $USER
+fi

--- a/scripts/restore_acl_experiment.sh
+++ b/scripts/restore_acl_experiment.sh
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Restore the ACLs on an experiment's directory tree.
+# The experiment folder gets the ACLs stored in the corresponding file under acl_files/
 # All files and folders in the directory tree, owned by the person who runs the
 # script, will have the following ACLs set:
 # group:<project_w>:rwX
@@ -14,7 +15,7 @@
 # files and directories need to be affected.
 # 
 # Input: 
-# exp_name: name of the experience we want to modify the ACLs. Format: YYYY-MM-DD_<exp-title>
+# exp_name: name of the experience we want to restore the ACLs. Format: YYYY-MM-DD_<exp-title>
 #
 
 # Parameters:
@@ -23,16 +24,30 @@ wg_root=/g/data/${wg_project}
 
 # Inputs:
 exp_name=$1
+if [ -z ${exp_name} ]; then 
+    echo "FAIL: You need to specify the experiment on the command line:"
+    echo "./restore_acl_experiment.sh <exp_name>"
+    exit 1
+fi
+
 exp_path=${wg_root}/experiments/${exp_name}
 if [ ! -d ${exp_path} ]; then
     echo "FAIL: The experiment directory, ${exp_path}, does not exist."
     exit 1
 fi
 
-# ACLs to set:
+if [ $(stat -c '%U' ${exp_path}) == $USER ]; then
+    # Restore ACLs on experiment directory
+    acl_filename=${wg_root}/admin/acl_files/${exp_name}
+    setfacl --restore=${acl_filename}
+fi
+
+# ACLs to set on files and subdirectories
 writer_acl=group:${wg_project}_w:rwX
 default_writer_acl=default:${writer_acl}
 mask_acl=mask::rwX
 
-# Set ACLs
-echo setfacl -R -m ${writer_acl} -m ${default_writer_acl} -m ${mask_acl} ${exp_path}/*
+# Set ACLs on files owned by the person running the script
+# We want to exclude ${exp_path} from the find results so we set mindepth=1.
+my_files=$(find ${exp_path}  -mindepth 1 -user $USER)
+setfacl -R -m ${writer_acl} -m ${default_writer_acl} -m ${mask_acl} ${my_files}

--- a/scripts/setfacl_experiments.sh
+++ b/scripts/setfacl_experiments.sh
@@ -60,15 +60,11 @@ fi
 
 acl_filename=${wg_root}/admin/acl_files/${exp_name}
 if [ ! -f $acl_filename ]; then
-    # getfacl removes leading '/' on absolute path which leads
-    # to file not found error in setfacl later. So convert
-    # absolute path to relative path.
-    # And we need to remove the last line in the created file
+    # We need to remove the last line in the created file
     # as getfacl leaves 2 empty lines at the end. This is so one
     # can concatenate the ACLs of several files in one file but it
-    # is not our current usecase.
-    real_exp=$(realpath --relative-to="$PWD" ${wg_root}/experiments/${exp_name} )
-    getfacl ${real_exp} > ${acl_filename}
+    # is not our current use case.
+    getfacl -p ${wg_root}/experiments/${exp_name} > ${acl_filename}
     sed -i '$ d' ${acl_filename}
 fi
 

--- a/scripts/setfacl_experiments.sh
+++ b/scripts/setfacl_experiments.sh
@@ -54,7 +54,12 @@ wg_project=$(stat -c '%G' $0)
 wg_root=/g/data/${wg_project}
 
 # Create exp. directory if needed
-if [ ! -d ${wg_root}/experiments/${exp_name} ]; then
+if [ -d ${wg_root}/experiments/${exp_name} ]; then
+    echo "FAIL: The experiment directory already exists. Running this script again would reset the ACLs. 
+    If you need to add new collaborators, run admin/scripts/add_collab_experiment.sh.
+    If you need to recreate the ACL file, specify a dummy project and then change the filename in the ACL file."
+    exit 1
+else
     mkdir ${wg_root}/experiments/${exp_name}
 fi
 

--- a/scripts/setfacl_experiments.sh
+++ b/scripts/setfacl_experiments.sh
@@ -1,0 +1,96 @@
+# Copyright 2024 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Set and restore the ACLs on an experiment folder. It will only modify the
+# ACLs of this folder.
+# 
+# Input: 
+# exp_name: name of the experience we want to modify the ACLs. Format: YYYY-MM-DD_<exp-title>
+#
+
+# Read in command line arguments (code is a mix from https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash and man getopt example) 
+help_text=0
+SHORT=e:u:h
+LONG=experiment:,users:,help
+
+PARSED=$(getopt --options $SHORT --longoptions $LONG --name "$0" -- "$@")
+if [[ $? != 0 ]] ; then echo "Wrong arguments. Terminating..." >&2 ; exit 1 ; fi
+
+
+eval set -- "$PARSED"
+
+while true; do
+    case "$1" in
+	-e|--experiments) exp_name="$2"; shift 2 ;;
+	-u|--users) users=(${2//,/ }); shift 2;;
+	-h|--help) help_text=1; shift ;;
+	--) shift; break ;;
+	*) echo "Programming error"; exit 1 ;;
+    esac
+done
+
+if [[ ${help_text} == 1 ]]; then
+    echo "The optional arguments are:"
+
+    # Experiment name
+    echo "-e, --experiment= followed by the name of the experiment. "
+    echo "    The name of the experiment should follow the format YYYY-MM-DD_<exp-title>."
+    echo
+    # Users
+    echo "-u, --users=  followed by the NCI login IDs of the users 
+    working on the experiment."
+    echo
+    # Help
+    echo "-h, --help  writes this help text"
+    echo
+
+    exit 0
+fi
+
+
+# Parameters:
+wg_project=$(stat -c '%G' $0)
+wg_root=/g/data/${wg_project}
+
+# Create exp. directory if needed
+if [ ! -d ${wg_root}/experiments/${exp_name} ]; then
+
+    mkdir ${wg_root}/experiments/${exp_name}
+fi
+
+acl_filename=${wg_root}/admin/acl_files/${exp_name}
+if [ ! -f $acl_filename ]; then
+    # getfacl removes leading '/' on absolute path which leads
+    # to file not found error in setfacl later. So convert
+    # absolute path to relative path.
+    # And we need to remove the last line in the created file
+    # as getfacl leaves 2 empty lines at the end. This is so one
+    # can concatenate the ACLs of several files in one file but it
+    # is not our current usecase.
+    real_exp=$(realpath --relative-to="$PWD" ${wg_root}/experiments/${exp_name} )
+    getfacl ${real_exp} > ${acl_filename}
+    sed -i '$ d' ${acl_filename}
+fi
+
+# Add ACLs for all the user IDs provided with rwx access
+for user in ${users}; do
+    acl=user:${user}:rwx
+    cat >> ${acl_filename} << EOF_gp
+${acl}
+EOF_gp
+done
+
+# Add ACLs for the writer projects to the ACL file if not already present.
+writer_acl=group:${wg_project}_w:rwx
+default_writer_acl=default:${writer_acl}
+
+for acl in $writer_acl $default_writer_acl; do
+    if ! grep -q -x -F "${acl}" "${acl_filename}"; then
+        cat >> ${acl_filename} << EOF_gp
+${acl}
+EOF_gp
+    fi
+done
+
+# Set the ACLs
+setfacl --restore=${acl_filename}

--- a/scripts/setfacl_experiments.sh
+++ b/scripts/setfacl_experiments.sh
@@ -74,7 +74,8 @@ if [ ! -f $acl_filename ]; then
 fi
 
 # Add ACLs for all the user IDs provided with rwx access
-for user in ${users}; do
+for user in ${users[@]}; do
+    echo $user
     acl=user:${user}:rwx
     cat >> ${acl_filename} << EOF_gp
 ${acl}

--- a/scripts/setfacl_experiments.sh
+++ b/scripts/setfacl_experiments.sh
@@ -1,11 +1,12 @@
 # Copyright 2024 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Set and restore the ACLs on an experiment folder. It will only modify the
-# ACLs of this folder.
+# Set the ACLs on an experiment folder. 
+# It creates the folder and sets the correct ACLs for the experiment.
 # 
 # Input: 
-# exp_name: name of the experience we want to modify the ACLs. Format: YYYY-MM-DD_<exp-title>
+# experiment: name of the experience we want to modify the ACLs. Format: YYYY-MM-DD_<exp-title>
+# users: NCI login IDs of the collaborators on the experiment
 #
 
 # Read in command line arguments (code is a mix from https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash and man getopt example) 
@@ -54,7 +55,6 @@ wg_root=/g/data/${wg_project}
 
 # Create exp. directory if needed
 if [ ! -d ${wg_root}/experiments/${exp_name} ]; then
-
     mkdir ${wg_root}/experiments/${exp_name}
 fi
 

--- a/scripts/setfacl_user_tree.sh
+++ b/scripts/setfacl_user_tree.sh
@@ -1,0 +1,38 @@
+# Copyright 2024 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Restore the ACLs on an experiment's directory tree.
+# All files and folders in the directory tree, owned by the person who runs the
+# script, will have the following ACLs set:
+# group:<project_w>:rwX
+# default:group:<project_w>:rwX
+# mask::rwX
+#
+# Any other existing ACL will not be modified.
+#
+# This script needs to be run by all the owners of files and directories if all
+# files and directories need to be affected.
+# 
+# Input: 
+# exp_name: name of the experience we want to modify the ACLs. Format: YYYY-MM-DD_<exp-title>
+#
+
+# Parameters:
+wg_project=$(stat -c '%G' $0)
+wg_root=/g/data/${wg_project}
+
+# Inputs:
+exp_name=$1
+exp_path=${wg_root}/experiments/${exp_name}
+if [ ! -d ${exp_path} ]; then
+    echo "FAIL: The experiment directory, ${exp_path}, does not exist."
+    exit 1
+fi
+
+# ACLs to set:
+writer_acl=group:${wg_project}_w:rwX
+default_writer_acl=default:${writer_acl}
+mask_acl=mask::rwX
+
+# Set ACLs
+echo setfacl -R -m ${writer_acl} -m ${default_writer_acl} -m ${mask_acl} ${exp_path}/*


### PR DESCRIPTION
This is all in BASH, some previous knowledge of ACLs might be useful for reviewing but a 5-minute read on the internet should do it.

`setfacl_experiments.sh`: set the ACLs on the root directory when creating the experiment
`add_collab_experiments.sh`: add collaborators (new users with write access)
`restore_acl_experiments.sh`: restore the ACLs on the experiment directory tree

See [explanation](https://forum.access-hive.org.au/t/wg-g-data-management-experiments-permissions/1862) on forum.

Testing: I have tested the scripts in wd9 (which has a writer group and has little activity). It worked as expected there.

Fixes #1 

